### PR TITLE
Change how the default types work

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -24,6 +24,7 @@ var TypeMap = map[int]string{
 	257: "CAA",
 }
 
+// Types returns all the supported DNS record types as strings
 func Types() []string {
 	var types []string
 	for _, value := range TypeMap {

--- a/dns.go
+++ b/dns.go
@@ -155,9 +155,15 @@ func DNS(args []string, s *discordgo.Session, m *discordgo.MessageCreate) {
 	// Allow user types if valid
 	var types []string
 	if len(args) >= 2 {
-		inter := Intersection(Types(), args)
-		if len(inter) > 0 {
-			types = inter
+		// If *, all types
+		if args[1] == "*" {
+			types = Types()
+		} else {
+			// Or, use valid types from provided
+			inter := Intersection(Types(), args)
+			if len(inter) > 0 {
+				types = inter
+			}
 		}
 	}
 

--- a/dns.go
+++ b/dns.go
@@ -24,6 +24,14 @@ var TypeMap = map[int]string{
 	257: "CAA",
 }
 
+func Types() []string {
+	var types []string
+	for _, value := range TypeMap {
+		types = append(types, value)
+	}
+	return types
+}
+
 type Question struct {
 	Name string `json:"name"`
 	Type int    `json:"type"`
@@ -144,17 +152,19 @@ func DNS(args []string, s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
-	// Default to all types
-	var types []string
-	for _, value := range TypeMap {
-		types = append(types, value)
-	}
-
 	// Allow user types if valid
+	var types []string
 	if len(args) >= 2 {
-		inter := Intersection(types, args)
+		inter := Intersection(Types(), args)
 		if len(inter) > 0 {
 			types = inter
+		}
+	}
+
+	// Default to A if no other types
+	if len(types) == 0 {
+		types = []string{
+			"A",
 		}
 	}
 

--- a/strings/usage.txt
+++ b/strings/usage.txt
@@ -1,8 +1,22 @@
 Usage: @1.1.1.1 <domain> [...types]
 
 Examples:
-@1.1.1.1 mattcowley.co.uk
-@1.1.1.1 mattcowley.co.uk A AAAA
+  @1.1.1.1 mattcowley.co.uk
+  @1.1.1.1 mattcowley.co.uk A AAAA
+
+Types:
+  If not provided, the default type of "A" will be used
+  You can provide a type of "*" to lookup all supported types
+
+Supported types:
+  A
+  NS
+  CNAME
+  MX
+  TXT
+  AAAA
+  SRV
+  CAA
 
 Invite: https://bit.ly/1111-Discord
 Open-source: https://github.com/MattIPv4/1.1.1.1-Discord


### PR DESCRIPTION
This PR makes the following changes:

 - If not types are defined, it will now default to `A` only.
 - If the type `*` is provided, it will use all supported types.